### PR TITLE
Migrate backend to FastAPI and fix e2e/script mismatches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -r backend/requirements.txt pytest
+      - run: python -m pytest backend/tests/
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run test:unit
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:e2e

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+A Project Management MVP: a single-user (MVP scope) Kanban board with an AI chat sidebar that can create/edit/move cards. Full requirements, technical decisions, and color scheme live in `AGENTS.md` (root) — read it before making product decisions. The build is being executed in phases tracked in `docs/PLAN.md`; check that file for current phase/status before assuming a feature (auth, database, AI wiring) is finished.
+
+Target architecture per `AGENTS.md`: NextJS frontend + Python FastAPI backend (serving the built static Next site at `/`), packaged as one Docker container, SQLite for storage, OpenRouter (`openai/gpt-oss-120b`) for AI calls, `uv` as the Python package manager in Docker.
+
+**Current implementation state (important, don't assume otherwise):** `backend/app.py` is now a FastAPI app (module-level `app = FastAPI()`) with `/api/health` and `/api/chat` (still keyword-based fake replies — no SQLite, no OpenRouter call yet). `python3 backend/app.py` runs it via `uvicorn.run()` in-process, so the OS-level process still shows up as `python3 backend/app.py` (relevant for `scripts/stop.sh`'s pkill pattern, see below). `backend/tests/test_chat.py` imports `from backend.app import app` and passes.
+
+The frontend Kanban board (`frontend/`) is a working, self-contained demo: board state lives in React state (`KanbanBoard.tsx`), not persisted to any backend yet. Sign-in is a hardcoded `user`/`password` check in client state (not real auth). `ChatPanel.tsx` calls `POST /api/chat` and expects `{ reply, updated_board? }`; `next.config.ts` rewrites `/api/:path*` to `http://127.0.0.1:8000/api/:path*` (the Python backend) in dev.
+
+## Commands
+
+### Frontend (`frontend/`)
+```bash
+npm install
+npm run dev            # Next dev server on :3000, proxies /api/* to :8000
+npm run build
+npm run lint
+npm run test:unit          # vitest run
+npm run test:unit:watch    # vitest watch
+npm run test:e2e           # playwright (auto-starts dev server on 127.0.0.1:3000)
+npm run test:all           # unit then e2e
+```
+Run a single vitest file/test: `npx vitest run src/components/KanbanBoard.test.tsx` or `npx vitest run -t "test name"`.
+Run a single playwright test: `npx playwright test tests/kanban.spec.ts -g "test name"`.
+Unit tests (vitest, jsdom) live alongside source as `*.test.tsx`/`*.test.ts`; e2e tests (Playwright) live in `frontend/tests/`. Don't put Playwright specs under `src/` — vitest's `include` is `src/**/*.{test,spec}.{ts,tsx}` and explicitly excludes `tests/`.
+
+### Backend (`backend/`)
+```bash
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r backend/requirements.txt
+python3 backend/app.py           # runs the current stdlib server on :8000
+```
+Backend tests use `unittest`/FastAPI's `TestClient` (`backend/tests/test_chat.py`) — run with `python -m pytest backend/tests/` or `python -m unittest discover backend/tests`.
+
+### Local dev (both services)
+```bash
+scripts/start.sh   # creates/activates .venv, starts backend (:8000) and frontend (:3000) in background, logs to /tmp/pm-backend.log and /tmp/pm-frontend.log
+scripts/stop.sh     # kills uvicorn and next dev processes
+```
+Note: `scripts/start.sh` launches the backend with `python3 backend/app.py` (which runs `uvicorn.run()` in-process); `scripts/stop.sh` pkills on `"backend/app.py"` to match that process's actual command line.
+
+## Architecture notes
+
+- **Board data model** (`frontend/src/lib/kanban.ts`): a `BoardData` is `{ columns: Column[], cards: Record<string, Card> }` — columns hold ordered `cardIds`, cards are looked up by id. `moveCard(columns, activeId, overId)` is the single pure function handling both same-column reorder and cross-column move logic for drag-and-drop; it's the place to change if drop behavior needs adjusting. It's unit-tested directly in `kanban.test.ts` — prefer testing move logic there over through the DnD component.
+- **Drag and drop**: `@dnd-kit/core` in `KanbanBoard.tsx` — `DndContext` wraps the columns, `handleDragEnd` calls `moveCard` and replaces `board.columns`. `KanbanCardPreview` renders the `DragOverlay` ghost.
+- **Chat → board update contract**: `ChatPanel` posts `{ message, board }` to `/api/chat` and merges back `data.updated_board` into board state via `onBoardUpdate` (passed down from `KanbanBoard`). Any backend chat implementation must honor this shape (`reply: string`, optional `updated_board: BoardData`) for the frontend to pick up AI-driven board edits.
+- **Styling**: Tailwind v4 (`@import "tailwindcss"` in `globals.css`, no separate config file) with the brand palette defined as CSS custom properties in `globals.css` (`--accent-yellow`, `--primary-blue`, `--secondary-purple`, `--navy-dark`, `--gray-text`) matching the values in `AGENTS.md`. Reference these vars (`var(--navy-dark)` etc.) rather than hardcoding hex values.
+- **E2e hooks**: Playwright tests rely on `data-testid` attributes (`column-<id>`, `card-<id>`) on the Kanban components — preserve these when refactoring markup.
+- Each of `backend/`, `scripts/`, and `frontend/` has (or is intended to have) its own `AGENTS.md` describing that subtree; `backend/AGENTS.md` and `scripts/AGENTS.md` are currently placeholders and should be filled in as those areas are built out.
+
+## Coding standards (from AGENTS.md)
+
+- Use latest, idiomatic versions of libraries.
+- Keep it simple — no over-engineering, no unnecessary defensive programming, no speculative features.
+- Keep docs/README minimal. No emojis, ever.
+- When debugging, find the root cause with evidence before fixing — don't guess-and-check.

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,60 @@
+import json
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse
+
+
+class BackendHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802
+        parsed = urlparse(self.path)
+        if parsed.path == "/api/health":
+            self._send_json(HTTPStatus.OK, {"status": "ok"})
+            return
+
+        self._send_json(HTTPStatus.NOT_FOUND, {"error": "not found"})
+
+    def do_POST(self) -> None:  # noqa: N802
+        parsed = urlparse(self.path)
+        if parsed.path != "/api/chat":
+            self._send_json(HTTPStatus.NOT_FOUND, {"error": "not found"})
+            return
+
+        length = int(self.headers.get("Content-Length", "0"))
+        raw_body = self.rfile.read(length) if length else b"{}"
+        try:
+            payload = json.loads(raw_body.decode("utf-8") or "{}")
+        except json.JSONDecodeError:
+            payload = {}
+
+        message = str(payload.get("message", "")).strip()
+        if not message:
+            self._send_json(HTTPStatus.BAD_REQUEST, {"reply": "Please enter a message."})
+            return
+
+        if "add" in message.lower() and "card" in message.lower():
+            reply = "I can add a card once the board is connected to the backend."
+        else:
+            reply = f"Echo: {message}"
+
+        self._send_json(HTTPStatus.OK, {"reply": reply})
+
+    def _send_json(self, status: HTTPStatus, payload: dict) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args) -> None:  # noqa: A003
+        return
+
+
+def main() -> None:
+    server = ThreadingHTTPServer(("0.0.0.0", 8000), BackendHandler)
+    print("Backend listening on http://0.0.0.0:8000")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,59 +1,38 @@
-import json
-from http import HTTPStatus
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from urllib.parse import urlparse
+from fastapi import FastAPI
+from pydantic import BaseModel
+from starlette.responses import JSONResponse
+
+app = FastAPI()
 
 
-class BackendHandler(BaseHTTPRequestHandler):
-    def do_GET(self) -> None:  # noqa: N802
-        parsed = urlparse(self.path)
-        if parsed.path == "/api/health":
-            self._send_json(HTTPStatus.OK, {"status": "ok"})
-            return
+class ChatRequest(BaseModel):
+    message: str = ""
+    board: dict = {}
 
-        self._send_json(HTTPStatus.NOT_FOUND, {"error": "not found"})
 
-    def do_POST(self) -> None:  # noqa: N802
-        parsed = urlparse(self.path)
-        if parsed.path != "/api/chat":
-            self._send_json(HTTPStatus.NOT_FOUND, {"error": "not found"})
-            return
+@app.get("/api/health")
+def health() -> dict:
+    return {"status": "ok"}
 
-        length = int(self.headers.get("Content-Length", "0"))
-        raw_body = self.rfile.read(length) if length else b"{}"
-        try:
-            payload = json.loads(raw_body.decode("utf-8") or "{}")
-        except json.JSONDecodeError:
-            payload = {}
 
-        message = str(payload.get("message", "")).strip()
-        if not message:
-            self._send_json(HTTPStatus.BAD_REQUEST, {"reply": "Please enter a message."})
-            return
+@app.post("/api/chat")
+def chat(payload: ChatRequest):
+    message = payload.message.strip()
+    if not message:
+        return JSONResponse(status_code=400, content={"reply": "Please enter a message."})
 
-        if "add" in message.lower() and "card" in message.lower():
-            reply = "I can add a card once the board is connected to the backend."
-        else:
-            reply = f"Echo: {message}"
+    if "add" in message.lower() and "card" in message.lower():
+        reply = "I can add a card once the board is connected to the backend."
+    else:
+        reply = f"Echo: {message}"
 
-        self._send_json(HTTPStatus.OK, {"reply": reply})
-
-    def _send_json(self, status: HTTPStatus, payload: dict) -> None:
-        body = json.dumps(payload).encode("utf-8")
-        self.send_response(status)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(body)))
-        self.end_headers()
-        self.wfile.write(body)
-
-    def log_message(self, format: str, *args) -> None:  # noqa: A003
-        return
+    return {"reply": reply}
 
 
 def main() -> None:
-    server = ThreadingHTTPServer(("0.0.0.0", 8000), BackendHandler)
-    print("Backend listening on http://0.0.0.0:8000")
-    server.serve_forever()
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)
 
 
 if __name__ == "__main__":

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.115.5
+uvicorn[standard]==0.32.0
+httpx==0.28.1
+pydantic==2.10.2

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -1,0 +1,30 @@
+import unittest
+
+from fastapi.testclient import TestClient
+
+from backend.app import app
+
+
+class ChatEndpointTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = TestClient(app)
+
+    def test_health_endpoint(self) -> None:
+        response = self.client.get("/api/health")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "ok")
+
+    def test_chat_endpoint_returns_reply(self) -> None:
+        response = self.client.post(
+            "/api/chat",
+            json={
+                "message": "Add a card for review",
+                "board": {"columns": [], "cards": {}},
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("reply", response.json())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async rewrites() {
+    return [
+      {
+        source: "/api/:path*",
+        destination: "http://127.0.0.1:8000/api/:path*",
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5438,7 +5438,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/frontend/src/components/ChatPanel.test.tsx
+++ b/frontend/src/components/ChatPanel.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ChatPanel } from "@/components/ChatPanel";
+import { initialData } from "@/lib/kanban";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ChatPanel", () => {
+  it("applies an updated board when the backend returns one", async () => {
+    const onBoardUpdate = vi.fn();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        json: async () => ({
+          reply: "Added card",
+          updated_board: {
+            ...initialData,
+            cards: {
+              ...initialData.cards,
+              "card-999": {
+                id: "card-999",
+                title: "Review task",
+                details: "Added from chat",
+              },
+            },
+          },
+        }),
+      })
+    );
+
+    render(<ChatPanel board={initialData} onBoardUpdate={onBoardUpdate} />);
+    await userEvent.type(
+      screen.getByPlaceholderText(/try: add a card for review/i),
+      "add a card for review"
+    );
+    await userEvent.click(screen.getByRole("button", { name: /send/i }));
+
+    expect(onBoardUpdate).toHaveBeenCalled();
+    expect(screen.getByText(/added card/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { SendIcon, SparkleIcon } from "@/components/icons";
 
 type ChatPanelProps = {
   board: {
@@ -44,8 +45,11 @@ export const ChatPanel = ({ board, onBoardUpdate }: ChatPanelProps) => {
   };
 
   return (
-    <aside className="rounded-[24px] border border-[var(--stroke)] bg-white/80 p-6 shadow-[var(--shadow)] backdrop-blur">
-      <h2 className="text-lg font-semibold text-[var(--navy-dark)]">Simple AI chat</h2>
+    <aside className="flex h-full flex-col rounded-[24px] border border-[var(--stroke)] bg-white/80 p-6 shadow-[var(--shadow)] backdrop-blur">
+      <div className="flex items-center gap-2">
+        <SparkleIcon className="h-5 w-5 text-[var(--secondary-purple)]" />
+        <h2 className="text-lg font-semibold text-[var(--navy-dark)]">Simple AI chat</h2>
+      </div>
       <p className="mt-2 text-sm text-[var(--gray-text)]">
         Send a short request and the backend will respond with a simple reply.
       </p>
@@ -59,12 +63,13 @@ export const ChatPanel = ({ board, onBoardUpdate }: ChatPanelProps) => {
         <button
           type="submit"
           disabled={loading}
-          className="rounded-full bg-[var(--secondary-purple)] px-4 py-2 text-sm font-semibold text-white disabled:opacity-60"
+          className="inline-flex items-center gap-2 rounded-full bg-[var(--secondary-purple)] px-4 py-2 text-sm font-semibold text-white disabled:opacity-60"
         >
+          <SendIcon className="h-4 w-4" />
           {loading ? "Sending..." : "Send"}
         </button>
       </form>
-      <div className="mt-4 rounded-2xl border border-[var(--stroke)] bg-[var(--surface)] p-4 text-sm text-[var(--navy-dark)]">
+      <div className="mt-4 flex-1 overflow-y-auto rounded-2xl border border-[var(--stroke)] bg-[var(--surface)] p-4 text-sm text-[var(--navy-dark)]">
         {reply}
       </div>
     </aside>

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState } from "react";
+
+type ChatPanelProps = {
+  board: {
+    columns: Array<{ id: string; title: string; cardIds: string[] }>;
+    cards: Record<string, { id: string; title: string; details: string }>;
+  };
+  onBoardUpdate?: (updatedBoard: ChatPanelProps["board"]) => void;
+};
+
+export const ChatPanel = ({ board, onBoardUpdate }: ChatPanelProps) => {
+  const [message, setMessage] = useState("");
+  const [reply, setReply] = useState("Ask for a simple change to the board.");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!message.trim()) {
+      return;
+    }
+
+    setLoading(true);
+    setReply("Thinking...");
+
+    try {
+      const response = await fetch("/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message, board }),
+      });
+      const data = await response.json();
+      setReply(data.reply || "No reply received.");
+      if (data.updated_board && onBoardUpdate) {
+        onBoardUpdate(data.updated_board);
+      }
+    } catch {
+      setReply("Chat service is unavailable right now.");
+    } finally {
+      setLoading(false);
+      setMessage("");
+    }
+  };
+
+  return (
+    <aside className="rounded-[24px] border border-[var(--stroke)] bg-white/80 p-6 shadow-[var(--shadow)] backdrop-blur">
+      <h2 className="text-lg font-semibold text-[var(--navy-dark)]">Simple AI chat</h2>
+      <p className="mt-2 text-sm text-[var(--gray-text)]">
+        Send a short request and the backend will respond with a simple reply.
+      </p>
+      <form onSubmit={handleSubmit} className="mt-4 space-y-3">
+        <textarea
+          value={message}
+          onChange={(event) => setMessage(event.target.value)}
+          placeholder="Try: add a card for review"
+          className="min-h-[96px] w-full rounded-2xl border border-[var(--stroke)] bg-[var(--surface)] px-4 py-3 text-sm outline-none ring-0"
+        />
+        <button
+          type="submit"
+          disabled={loading}
+          className="rounded-full bg-[var(--secondary-purple)] px-4 py-2 text-sm font-semibold text-white disabled:opacity-60"
+        >
+          {loading ? "Sending..." : "Send"}
+        </button>
+      </form>
+      <div className="mt-4 rounded-2xl border border-[var(--stroke)] bg-[var(--surface)] p-4 text-sm text-[var(--navy-dark)]">
+        {reply}
+      </div>
+    </aside>
+  );
+};

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -2,13 +2,11 @@
 
 import { useState } from "react";
 import { SendIcon, SparkleIcon } from "@/components/icons";
+import type { BoardData } from "@/lib/kanban";
 
 type ChatPanelProps = {
-  board: {
-    columns: Array<{ id: string; title: string; cardIds: string[] }>;
-    cards: Record<string, { id: string; title: string; details: string }>;
-  };
-  onBoardUpdate?: (updatedBoard: ChatPanelProps["board"]) => void;
+  board: BoardData;
+  onBoardUpdate?: (updatedBoard: BoardData) => void;
 };
 
 export const ChatPanel = ({ board, onBoardUpdate }: ChatPanelProps) => {

--- a/frontend/src/components/KanbanBoard.test.tsx
+++ b/frontend/src/components/KanbanBoard.test.tsx
@@ -4,6 +4,12 @@ import { KanbanBoard } from "@/components/KanbanBoard";
 
 const getFirstColumn = () => screen.getAllByTestId(/column-/i)[0];
 
+const signIn = async () => {
+  await userEvent.type(screen.getByLabelText(/username/i), "user");
+  await userEvent.type(screen.getByLabelText(/password/i), "password");
+  await userEvent.click(screen.getByRole("button", { name: /sign in/i }));
+};
+
 describe("KanbanBoard", () => {
   it("shows a login form before the board is available", () => {
     render(<KanbanBoard />);
@@ -14,9 +20,7 @@ describe("KanbanBoard", () => {
 
   it("allows a user to sign in and out", async () => {
     render(<KanbanBoard />);
-    await userEvent.type(screen.getByLabelText(/username/i), "user");
-    await userEvent.type(screen.getByLabelText(/password/i), "password");
-    await userEvent.click(screen.getByRole("button", { name: /sign in/i }));
+    await signIn();
 
     expect(screen.getAllByTestId(/column-/i)).toHaveLength(5);
 
@@ -26,17 +30,13 @@ describe("KanbanBoard", () => {
 
   it("renders five columns", async () => {
     render(<KanbanBoard />);
-    await userEvent.type(screen.getByLabelText(/username/i), "user");
-    await userEvent.type(screen.getByLabelText(/password/i), "password");
-    await userEvent.click(screen.getByRole("button", { name: /sign in/i }));
+    await signIn();
     expect(screen.getAllByTestId(/column-/i)).toHaveLength(5);
   });
 
   it("renames a column", async () => {
     render(<KanbanBoard />);
-    await userEvent.type(screen.getByLabelText(/username/i), "user");
-    await userEvent.type(screen.getByLabelText(/password/i), "password");
-    await userEvent.click(screen.getByRole("button", { name: /sign in/i }));
+    await signIn();
     const column = getFirstColumn();
     const input = within(column).getByLabelText("Column title");
     await userEvent.clear(input);
@@ -46,9 +46,7 @@ describe("KanbanBoard", () => {
 
   it("adds and removes a card", async () => {
     render(<KanbanBoard />);
-    await userEvent.type(screen.getByLabelText(/username/i), "user");
-    await userEvent.type(screen.getByLabelText(/password/i), "password");
-    await userEvent.click(screen.getByRole("button", { name: /sign in/i }));
+    await signIn();
     const column = getFirstColumn();
     const addButton = within(column).getByRole("button", {
       name: /add a card/i,

--- a/frontend/src/components/KanbanBoard.test.tsx
+++ b/frontend/src/components/KanbanBoard.test.tsx
@@ -5,13 +5,38 @@ import { KanbanBoard } from "@/components/KanbanBoard";
 const getFirstColumn = () => screen.getAllByTestId(/column-/i)[0];
 
 describe("KanbanBoard", () => {
-  it("renders five columns", () => {
+  it("shows a login form before the board is available", () => {
     render(<KanbanBoard />);
+    expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+    expect(screen.queryAllByTestId(/column-/i)).toHaveLength(0);
+  });
+
+  it("allows a user to sign in and out", async () => {
+    render(<KanbanBoard />);
+    await userEvent.type(screen.getByLabelText(/username/i), "user");
+    await userEvent.type(screen.getByLabelText(/password/i), "password");
+    await userEvent.click(screen.getByRole("button", { name: /sign in/i }));
+
+    expect(screen.getAllByTestId(/column-/i)).toHaveLength(5);
+
+    await userEvent.click(screen.getByRole("button", { name: /log out/i }));
+    expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
+  });
+
+  it("renders five columns", async () => {
+    render(<KanbanBoard />);
+    await userEvent.type(screen.getByLabelText(/username/i), "user");
+    await userEvent.type(screen.getByLabelText(/password/i), "password");
+    await userEvent.click(screen.getByRole("button", { name: /sign in/i }));
     expect(screen.getAllByTestId(/column-/i)).toHaveLength(5);
   });
 
   it("renames a column", async () => {
     render(<KanbanBoard />);
+    await userEvent.type(screen.getByLabelText(/username/i), "user");
+    await userEvent.type(screen.getByLabelText(/password/i), "password");
+    await userEvent.click(screen.getByRole("button", { name: /sign in/i }));
     const column = getFirstColumn();
     const input = within(column).getByLabelText("Column title");
     await userEvent.clear(input);
@@ -21,6 +46,9 @@ describe("KanbanBoard", () => {
 
   it("adds and removes a card", async () => {
     render(<KanbanBoard />);
+    await userEvent.type(screen.getByLabelText(/username/i), "user");
+    await userEvent.type(screen.getByLabelText(/password/i), "password");
+    await userEvent.click(screen.getByRole("button", { name: /sign in/i }));
     const column = getFirstColumn();
     const addButton = within(column).getByRole("button", {
       name: /add a card/i,

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -13,11 +13,16 @@ import {
 } from "@dnd-kit/core";
 import { KanbanColumn } from "@/components/KanbanColumn";
 import { KanbanCardPreview } from "@/components/KanbanCardPreview";
+import { ChatPanel } from "@/components/ChatPanel";
 import { createId, initialData, moveCard, type BoardData } from "@/lib/kanban";
 
 export const KanbanBoard = () => {
   const [board, setBoard] = useState<BoardData>(() => initialData);
   const [activeCardId, setActiveCardId] = useState<string | null>(null);
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [isSignedIn, setIsSignedIn] = useState(false);
+  const [loginError, setLoginError] = useState("");
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -91,6 +96,74 @@ export const KanbanBoard = () => {
 
   const activeCard = activeCardId ? cardsById[activeCardId] : null;
 
+  const handleSignIn = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (username === "user" && password === "password") {
+      setIsSignedIn(true);
+      setLoginError("");
+      return;
+    }
+    setLoginError("Use user / password to continue.");
+  };
+
+  const handleSignOut = () => {
+    setIsSignedIn(false);
+    setUsername("");
+    setPassword("");
+    setLoginError("");
+  };
+
+  if (!isSignedIn) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[var(--surface)] px-6 py-12">
+        <form
+          onSubmit={handleSignIn}
+          className="w-full max-w-md rounded-[32px] border border-[var(--stroke)] bg-white p-8 shadow-[var(--shadow)]"
+        >
+          <p className="text-xs font-semibold uppercase tracking-[0.35em] text-[var(--gray-text)]">
+            Sign in
+          </p>
+          <h1 className="mt-3 text-3xl font-semibold text-[var(--navy-dark)]">
+            Welcome back
+          </h1>
+          <p className="mt-3 text-sm leading-6 text-[var(--gray-text)]">
+            Use the demo credentials to view the board.
+          </p>
+          <div className="mt-6 space-y-4">
+            <label className="block text-sm font-medium text-[var(--navy-dark)]">
+              Username
+              <input
+                aria-label="Username"
+                value={username}
+                onChange={(event) => setUsername(event.target.value)}
+                className="mt-2 w-full rounded-2xl border border-[var(--stroke)] px-4 py-3 text-sm outline-none"
+              />
+            </label>
+            <label className="block text-sm font-medium text-[var(--navy-dark)]">
+              Password
+              <input
+                aria-label="Password"
+                type="password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                className="mt-2 w-full rounded-2xl border border-[var(--stroke)] px-4 py-3 text-sm outline-none"
+              />
+            </label>
+          </div>
+          {loginError ? (
+            <p className="mt-4 text-sm text-red-600">{loginError}</p>
+          ) : null}
+          <button
+            type="submit"
+            className="mt-6 w-full rounded-full bg-[var(--secondary-purple)] px-4 py-3 text-sm font-semibold text-white"
+          >
+            Sign in
+          </button>
+        </form>
+      </div>
+    );
+  }
+
   return (
     <div className="relative overflow-hidden">
       <div className="pointer-events-none absolute left-0 top-0 h-[420px] w-[420px] -translate-x-1/3 -translate-y-1/3 rounded-full bg-[radial-gradient(circle,_rgba(32,157,215,0.25)_0%,_rgba(32,157,215,0.05)_55%,_transparent_70%)]" />
@@ -111,13 +184,22 @@ export const KanbanBoard = () => {
                 and capture quick notes without getting buried in settings.
               </p>
             </div>
-            <div className="rounded-2xl border border-[var(--stroke)] bg-[var(--surface)] px-5 py-4">
-              <p className="text-xs font-semibold uppercase tracking-[0.25em] text-[var(--gray-text)]">
-                Focus
-              </p>
-              <p className="mt-2 text-lg font-semibold text-[var(--primary-blue)]">
-                One board. Five columns. Zero clutter.
-              </p>
+            <div className="flex flex-wrap items-center gap-3">
+              <div className="rounded-2xl border border-[var(--stroke)] bg-[var(--surface)] px-5 py-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.25em] text-[var(--gray-text)]">
+                  Focus
+                </p>
+                <p className="mt-2 text-lg font-semibold text-[var(--primary-blue)]">
+                  One board. Five columns. Zero clutter.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={handleSignOut}
+                className="rounded-full border border-[var(--stroke)] px-4 py-2 text-sm font-semibold text-[var(--navy-dark)]"
+              >
+                Log out
+              </button>
             </div>
           </div>
           <div className="flex flex-wrap items-center gap-4">
@@ -133,32 +215,35 @@ export const KanbanBoard = () => {
           </div>
         </header>
 
-        <DndContext
-          sensors={sensors}
-          collisionDetection={closestCorners}
-          onDragStart={handleDragStart}
-          onDragEnd={handleDragEnd}
-        >
-          <section className="grid gap-6 lg:grid-cols-5">
-            {board.columns.map((column) => (
-              <KanbanColumn
-                key={column.id}
-                column={column}
-                cards={column.cardIds.map((cardId) => board.cards[cardId])}
-                onRename={handleRenameColumn}
-                onAddCard={handleAddCard}
-                onDeleteCard={handleDeleteCard}
-              />
-            ))}
-          </section>
-          <DragOverlay>
-            {activeCard ? (
-              <div className="w-[260px]">
-                <KanbanCardPreview card={activeCard} />
-              </div>
-            ) : null}
-          </DragOverlay>
-        </DndContext>
+        <div className="grid gap-6 xl:grid-cols-[1.7fr_0.8fr]">
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCorners}
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+          >
+            <section className="grid gap-6 lg:grid-cols-5">
+              {board.columns.map((column) => (
+                <KanbanColumn
+                  key={column.id}
+                  column={column}
+                  cards={column.cardIds.map((cardId) => board.cards[cardId])}
+                  onRename={handleRenameColumn}
+                  onAddCard={handleAddCard}
+                  onDeleteCard={handleDeleteCard}
+                />
+              ))}
+            </section>
+            <DragOverlay>
+              {activeCard ? (
+                <div className="w-[260px]">
+                  <KanbanCardPreview card={activeCard} />
+                </div>
+              ) : null}
+            </DragOverlay>
+          </DndContext>
+          <ChatPanel board={board} onBoardUpdate={setBoard} />
+        </div>
       </main>
     </div>
   );

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -14,6 +14,7 @@ import {
 import { KanbanColumn } from "@/components/KanbanColumn";
 import { KanbanCardPreview } from "@/components/KanbanCardPreview";
 import { ChatPanel } from "@/components/ChatPanel";
+import { LogOutIcon } from "@/components/icons";
 import { createId, initialData, moveCard, type BoardData } from "@/lib/kanban";
 
 export const KanbanBoard = () => {
@@ -169,7 +170,7 @@ export const KanbanBoard = () => {
       <div className="pointer-events-none absolute left-0 top-0 h-[420px] w-[420px] -translate-x-1/3 -translate-y-1/3 rounded-full bg-[radial-gradient(circle,_rgba(32,157,215,0.25)_0%,_rgba(32,157,215,0.05)_55%,_transparent_70%)]" />
       <div className="pointer-events-none absolute bottom-0 right-0 h-[520px] w-[520px] translate-x-1/4 translate-y-1/4 rounded-full bg-[radial-gradient(circle,_rgba(117,57,145,0.18)_0%,_rgba(117,57,145,0.05)_55%,_transparent_75%)]" />
 
-      <main className="relative mx-auto flex min-h-screen max-w-[1500px] flex-col gap-10 px-6 pb-16 pt-12">
+      <main className="relative mx-auto flex min-h-screen max-w-[1920px] flex-col gap-8 px-6 pb-16 pt-12">
         <header className="flex flex-col gap-6 rounded-[32px] border border-[var(--stroke)] bg-white/80 p-8 shadow-[var(--shadow)] backdrop-blur">
           <div className="flex flex-wrap items-start justify-between gap-6">
             <div>
@@ -196,8 +197,9 @@ export const KanbanBoard = () => {
               <button
                 type="button"
                 onClick={handleSignOut}
-                className="rounded-full border border-[var(--stroke)] px-4 py-2 text-sm font-semibold text-[var(--navy-dark)]"
+                className="inline-flex items-center gap-2 rounded-full border border-[var(--stroke)] px-4 py-2 text-sm font-semibold text-[var(--navy-dark)] transition hover:bg-[var(--surface)]"
               >
+                <LogOutIcon className="h-4 w-4" />
                 Log out
               </button>
             </div>
@@ -215,23 +217,24 @@ export const KanbanBoard = () => {
           </div>
         </header>
 
-        <div className="grid gap-6 xl:grid-cols-[1.7fr_0.8fr]">
+        <div className="flex flex-1 flex-col gap-6 xl:flex-row xl:items-start">
           <DndContext
             sensors={sensors}
             collisionDetection={closestCorners}
             onDragStart={handleDragStart}
             onDragEnd={handleDragEnd}
           >
-            <section className="grid gap-6 lg:grid-cols-5">
+            <section className="flex min-w-0 flex-1 gap-5 overflow-x-auto pb-2">
               {board.columns.map((column) => (
-                <KanbanColumn
-                  key={column.id}
-                  column={column}
-                  cards={column.cardIds.map((cardId) => board.cards[cardId])}
-                  onRename={handleRenameColumn}
-                  onAddCard={handleAddCard}
-                  onDeleteCard={handleDeleteCard}
-                />
+                <div key={column.id} className="w-[280px] shrink-0 grow">
+                  <KanbanColumn
+                    column={column}
+                    cards={column.cardIds.map((cardId) => board.cards[cardId])}
+                    onRename={handleRenameColumn}
+                    onAddCard={handleAddCard}
+                    onDeleteCard={handleDeleteCard}
+                  />
+                </div>
               ))}
             </section>
             <DragOverlay>
@@ -242,7 +245,9 @@ export const KanbanBoard = () => {
               ) : null}
             </DragOverlay>
           </DndContext>
-          <ChatPanel board={board} onBoardUpdate={setBoard} />
+          <div className="xl:sticky xl:top-6 xl:w-[360px] xl:shrink-0">
+            <ChatPanel board={board} onBoardUpdate={setBoard} />
+          </div>
         </div>
       </main>
     </div>

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import {
   DndContext,
   DragOverlay,
@@ -15,7 +15,14 @@ import { KanbanColumn } from "@/components/KanbanColumn";
 import { KanbanCardPreview } from "@/components/KanbanCardPreview";
 import { ChatPanel } from "@/components/ChatPanel";
 import { LogOutIcon } from "@/components/icons";
-import { createId, initialData, moveCard, type BoardData } from "@/lib/kanban";
+import {
+  addCard,
+  initialData,
+  moveCard,
+  removeCard,
+  renameColumn,
+  type BoardData,
+} from "@/lib/kanban";
 
 export const KanbanBoard = () => {
   const [board, setBoard] = useState<BoardData>(() => initialData);
@@ -31,7 +38,7 @@ export const KanbanBoard = () => {
     })
   );
 
-  const cardsById = useMemo(() => board.cards, [board.cards]);
+  const cardsById = board.cards;
 
   const handleDragStart = (event: DragStartEvent) => {
     setActiveCardId(event.active.id as string);
@@ -54,45 +61,16 @@ export const KanbanBoard = () => {
   const handleRenameColumn = (columnId: string, title: string) => {
     setBoard((prev) => ({
       ...prev,
-      columns: prev.columns.map((column) =>
-        column.id === columnId ? { ...column, title } : column
-      ),
+      columns: renameColumn(prev.columns, columnId, title),
     }));
   };
 
   const handleAddCard = (columnId: string, title: string, details: string) => {
-    const id = createId("card");
-    setBoard((prev) => ({
-      ...prev,
-      cards: {
-        ...prev.cards,
-        [id]: { id, title, details: details || "No details yet." },
-      },
-      columns: prev.columns.map((column) =>
-        column.id === columnId
-          ? { ...column, cardIds: [...column.cardIds, id] }
-          : column
-      ),
-    }));
+    setBoard((prev) => addCard(prev, columnId, title, details));
   };
 
   const handleDeleteCard = (columnId: string, cardId: string) => {
-    setBoard((prev) => {
-      return {
-        ...prev,
-        cards: Object.fromEntries(
-          Object.entries(prev.cards).filter(([id]) => id !== cardId)
-        ),
-        columns: prev.columns.map((column) =>
-          column.id === columnId
-            ? {
-                ...column,
-                cardIds: column.cardIds.filter((id) => id !== cardId),
-              }
-            : column
-        ),
-      };
-    });
+    setBoard((prev) => removeCard(prev, columnId, cardId));
   };
 
   const activeCard = activeCardId ? cardsById[activeCardId] : null;

--- a/frontend/src/components/KanbanCard.tsx
+++ b/frontend/src/components/KanbanCard.tsx
@@ -2,6 +2,7 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import clsx from "clsx";
 import type { Card } from "@/lib/kanban";
+import { TrashIcon } from "@/components/icons";
 
 type KanbanCardProps = {
   card: Card;
@@ -31,7 +32,7 @@ export const KanbanCard = ({ card, onDelete }: KanbanCardProps) => {
       data-testid={`card-${card.id}`}
     >
       <div className="flex items-start justify-between gap-3">
-        <div>
+        <div className="min-w-0">
           <h4 className="font-display text-base font-semibold text-[var(--navy-dark)]">
             {card.title}
           </h4>
@@ -42,10 +43,11 @@ export const KanbanCard = ({ card, onDelete }: KanbanCardProps) => {
         <button
           type="button"
           onClick={() => onDelete(card.id)}
-          className="rounded-full border border-transparent px-2 py-1 text-xs font-semibold text-[var(--gray-text)] transition hover:border-[var(--stroke)] hover:text-[var(--navy-dark)]"
+          className="shrink-0 rounded-full border border-transparent p-1.5 text-[var(--gray-text)] transition hover:border-[var(--stroke)] hover:bg-red-50 hover:text-red-600"
           aria-label={`Delete ${card.title}`}
+          title="Delete card"
         >
-          Remove
+          <TrashIcon />
         </button>
       </div>
     </article>

--- a/frontend/src/components/KanbanCard.tsx
+++ b/frontend/src/components/KanbanCard.tsx
@@ -3,6 +3,7 @@ import { CSS } from "@dnd-kit/utilities";
 import clsx from "clsx";
 import type { Card } from "@/lib/kanban";
 import { TrashIcon } from "@/components/icons";
+import { KanbanCardContent } from "@/components/KanbanCardContent";
 
 type KanbanCardProps = {
   card: Card;
@@ -32,14 +33,7 @@ export const KanbanCard = ({ card, onDelete }: KanbanCardProps) => {
       data-testid={`card-${card.id}`}
     >
       <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <h4 className="font-display text-base font-semibold text-[var(--navy-dark)]">
-            {card.title}
-          </h4>
-          <p className="mt-2 text-sm leading-6 text-[var(--gray-text)]">
-            {card.details}
-          </p>
-        </div>
+        <KanbanCardContent card={card} />
         <button
           type="button"
           onClick={() => onDelete(card.id)}

--- a/frontend/src/components/KanbanCardContent.tsx
+++ b/frontend/src/components/KanbanCardContent.tsx
@@ -1,0 +1,12 @@
+import type { Card } from "@/lib/kanban";
+
+export const KanbanCardContent = ({ card }: { card: Card }) => (
+  <div className="min-w-0">
+    <h4 className="font-display text-base font-semibold text-[var(--navy-dark)]">
+      {card.title}
+    </h4>
+    <p className="mt-2 text-sm leading-6 text-[var(--gray-text)]">
+      {card.details}
+    </p>
+  </div>
+);

--- a/frontend/src/components/KanbanCardPreview.tsx
+++ b/frontend/src/components/KanbanCardPreview.tsx
@@ -1,4 +1,5 @@
 import type { Card } from "@/lib/kanban";
+import { KanbanCardContent } from "@/components/KanbanCardContent";
 
 type KanbanCardPreviewProps = {
   card: Card;
@@ -6,15 +7,6 @@ type KanbanCardPreviewProps = {
 
 export const KanbanCardPreview = ({ card }: KanbanCardPreviewProps) => (
   <article className="rounded-2xl border border-transparent bg-white px-4 py-4 shadow-[0_18px_32px_rgba(3,33,71,0.16)]">
-    <div className="flex items-start justify-between gap-3">
-      <div>
-        <h4 className="font-display text-base font-semibold text-[var(--navy-dark)]">
-          {card.title}
-        </h4>
-        <p className="mt-2 text-sm leading-6 text-[var(--gray-text)]">
-          {card.details}
-        </p>
-      </div>
-    </div>
+    <KanbanCardContent card={card} />
   </article>
 );

--- a/frontend/src/components/NewCardForm.tsx
+++ b/frontend/src/components/NewCardForm.tsx
@@ -1,4 +1,5 @@
 import { useState, type FormEvent } from "react";
+import { PlusIcon, XIcon } from "@/components/icons";
 
 const initialFormState = { title: "", details: "" };
 
@@ -45,8 +46,9 @@ export const NewCardForm = ({ onAdd }: NewCardFormProps) => {
           <div className="flex items-center gap-2">
             <button
               type="submit"
-              className="rounded-full bg-[var(--secondary-purple)] px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white transition hover:brightness-110"
+              className="inline-flex items-center gap-1.5 rounded-full bg-[var(--secondary-purple)] px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white transition hover:brightness-110"
             >
+              <PlusIcon className="h-3.5 w-3.5" />
               Add card
             </button>
             <button
@@ -55,8 +57,9 @@ export const NewCardForm = ({ onAdd }: NewCardFormProps) => {
                 setIsOpen(false);
                 setFormState(initialFormState);
               }}
-              className="rounded-full border border-[var(--stroke)] px-3 py-2 text-xs font-semibold uppercase tracking-wide text-[var(--gray-text)] transition hover:text-[var(--navy-dark)]"
+              className="inline-flex items-center gap-1.5 rounded-full border border-[var(--stroke)] px-3 py-2 text-xs font-semibold uppercase tracking-wide text-[var(--gray-text)] transition hover:text-[var(--navy-dark)]"
             >
+              <XIcon className="h-3.5 w-3.5" />
               Cancel
             </button>
           </div>
@@ -65,8 +68,9 @@ export const NewCardForm = ({ onAdd }: NewCardFormProps) => {
         <button
           type="button"
           onClick={() => setIsOpen(true)}
-          className="w-full rounded-full border border-dashed border-[var(--stroke)] px-3 py-2 text-xs font-semibold uppercase tracking-wide text-[var(--primary-blue)] transition hover:border-[var(--primary-blue)]"
+          className="inline-flex w-full items-center justify-center gap-1.5 rounded-full border border-dashed border-[var(--stroke)] px-3 py-2 text-xs font-semibold uppercase tracking-wide text-[var(--primary-blue)] transition hover:border-[var(--primary-blue)]"
         >
+          <PlusIcon className="h-3.5 w-3.5" />
           Add a card
         </button>
       )}

--- a/frontend/src/components/icons.tsx
+++ b/frontend/src/components/icons.tsx
@@ -1,0 +1,105 @@
+type IconProps = {
+  className?: string;
+};
+
+const base = "h-4 w-4";
+
+export const TrashIcon = ({ className }: IconProps) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.8}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className ?? base}
+    aria-hidden="true"
+  >
+    <path d="M4 7h16" />
+    <path d="M10 11v6" />
+    <path d="M14 11v6" />
+    <path d="M6 7l1 12a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2l1-12" />
+    <path d="M9 7V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v3" />
+  </svg>
+);
+
+export const PlusIcon = ({ className }: IconProps) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.8}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className ?? base}
+    aria-hidden="true"
+  >
+    <path d="M12 5v14" />
+    <path d="M5 12h14" />
+  </svg>
+);
+
+export const XIcon = ({ className }: IconProps) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.8}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className ?? base}
+    aria-hidden="true"
+  >
+    <path d="M6 6l12 12" />
+    <path d="M18 6L6 18" />
+  </svg>
+);
+
+export const SendIcon = ({ className }: IconProps) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.8}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className ?? base}
+    aria-hidden="true"
+  >
+    <path d="M22 2L11 13" />
+    <path d="M22 2l-7 20-4-9-9-4 20-7z" />
+  </svg>
+);
+
+export const LogOutIcon = ({ className }: IconProps) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.8}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className ?? base}
+    aria-hidden="true"
+  >
+    <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+    <path d="M16 17l5-5-5-5" />
+    <path d="M21 12H9" />
+  </svg>
+);
+
+export const SparkleIcon = ({ className }: IconProps) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.8}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className ?? base}
+    aria-hidden="true"
+  >
+    <path d="M12 3l1.8 4.9L19 9.5l-4.9 1.8L12 16l-1.8-4.7L5 9.5l5.2-1.6L12 3z" />
+    <path d="M19 15l.9 2.4L22 18l-2.1.9L19 21l-.9-2.1L16 18l2.1-.6z" />
+  </svg>
+);

--- a/frontend/src/components/icons.tsx
+++ b/frontend/src/components/icons.tsx
@@ -1,10 +1,15 @@
+import type { ReactNode } from "react";
+
 type IconProps = {
   className?: string;
 };
 
 const base = "h-4 w-4";
 
-export const TrashIcon = ({ className }: IconProps) => (
+const IconBase = ({
+  className,
+  children,
+}: IconProps & { children: ReactNode }) => (
   <svg
     viewBox="0 0 24 24"
     fill="none"
@@ -15,91 +20,52 @@ export const TrashIcon = ({ className }: IconProps) => (
     className={className ?? base}
     aria-hidden="true"
   >
+    {children}
+  </svg>
+);
+
+export const TrashIcon = ({ className }: IconProps) => (
+  <IconBase className={className}>
     <path d="M4 7h16" />
     <path d="M10 11v6" />
     <path d="M14 11v6" />
     <path d="M6 7l1 12a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2l1-12" />
     <path d="M9 7V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v3" />
-  </svg>
+  </IconBase>
 );
 
 export const PlusIcon = ({ className }: IconProps) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.8}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    className={className ?? base}
-    aria-hidden="true"
-  >
+  <IconBase className={className}>
     <path d="M12 5v14" />
     <path d="M5 12h14" />
-  </svg>
+  </IconBase>
 );
 
 export const XIcon = ({ className }: IconProps) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.8}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    className={className ?? base}
-    aria-hidden="true"
-  >
+  <IconBase className={className}>
     <path d="M6 6l12 12" />
     <path d="M18 6L6 18" />
-  </svg>
+  </IconBase>
 );
 
 export const SendIcon = ({ className }: IconProps) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.8}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    className={className ?? base}
-    aria-hidden="true"
-  >
+  <IconBase className={className}>
     <path d="M22 2L11 13" />
     <path d="M22 2l-7 20-4-9-9-4 20-7z" />
-  </svg>
+  </IconBase>
 );
 
 export const LogOutIcon = ({ className }: IconProps) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.8}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    className={className ?? base}
-    aria-hidden="true"
-  >
+  <IconBase className={className}>
     <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
     <path d="M16 17l5-5-5-5" />
     <path d="M21 12H9" />
-  </svg>
+  </IconBase>
 );
 
 export const SparkleIcon = ({ className }: IconProps) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.8}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    className={className ?? base}
-    aria-hidden="true"
-  >
+  <IconBase className={className}>
     <path d="M12 3l1.8 4.9L19 9.5l-4.9 1.8L12 16l-1.8-4.7L5 9.5l5.2-1.6L12 3z" />
     <path d="M19 15l.9 2.4L22 18l-2.1.9L19 21l-.9-2.1L16 18l2.1-.6z" />
-  </svg>
+  </IconBase>
 );

--- a/frontend/src/lib/kanban.test.ts
+++ b/frontend/src/lib/kanban.test.ts
@@ -1,4 +1,11 @@
-import { moveCard, type Column } from "@/lib/kanban";
+import {
+  addCard,
+  moveCard,
+  removeCard,
+  renameColumn,
+  type BoardData,
+  type Column,
+} from "@/lib/kanban";
 
 describe("moveCard", () => {
   const baseColumns: Column[] = [
@@ -21,5 +28,47 @@ describe("moveCard", () => {
     const result = moveCard(baseColumns, "card-1", "col-b");
     expect(result[0].cardIds).toEqual(["card-2"]);
     expect(result[1].cardIds).toEqual(["card-3", "card-1"]);
+  });
+});
+
+describe("renameColumn", () => {
+  it("renames the matching column and leaves others untouched", () => {
+    const columns: Column[] = [
+      { id: "col-a", title: "A", cardIds: [] },
+      { id: "col-b", title: "B", cardIds: [] },
+    ];
+    const result = renameColumn(columns, "col-a", "Renamed");
+    expect(result[0].title).toBe("Renamed");
+    expect(result[1].title).toBe("B");
+  });
+});
+
+describe("addCard and removeCard", () => {
+  const board: BoardData = {
+    columns: [{ id: "col-a", title: "A", cardIds: ["card-1"] }],
+    cards: { "card-1": { id: "card-1", title: "Existing", details: "" } },
+  };
+
+  it("adds a card to the target column", () => {
+    const result = addCard(board, "col-a", "New card", "Notes");
+    expect(result.columns[0].cardIds).toHaveLength(2);
+    const newId = result.columns[0].cardIds[1];
+    expect(result.cards[newId]).toEqual({
+      id: newId,
+      title: "New card",
+      details: "Notes",
+    });
+  });
+
+  it("defaults details when none are given", () => {
+    const result = addCard(board, "col-a", "New card", "");
+    const newId = result.columns[0].cardIds[1];
+    expect(result.cards[newId].details).toBe("No details yet.");
+  });
+
+  it("removes a card from its column and the cards map", () => {
+    const result = removeCard(board, "col-a", "card-1");
+    expect(result.columns[0].cardIds).toEqual([]);
+    expect(result.cards["card-1"]).toBeUndefined();
   });
 });

--- a/frontend/src/lib/kanban.ts
+++ b/frontend/src/lib/kanban.ts
@@ -166,3 +166,51 @@ export const createId = (prefix: string) => {
   const timePart = Date.now().toString(36);
   return `${prefix}-${randomPart}${timePart}`;
 };
+
+export const renameColumn = (
+  columns: Column[],
+  columnId: string,
+  title: string
+): Column[] =>
+  columns.map((column) =>
+    column.id === columnId ? { ...column, title } : column
+  );
+
+export const addCard = (
+  board: BoardData,
+  columnId: string,
+  title: string,
+  details: string
+): BoardData => {
+  const id = createId("card");
+  return {
+    ...board,
+    cards: {
+      ...board.cards,
+      [id]: { id, title, details: details || "No details yet." },
+    },
+    columns: board.columns.map((column) =>
+      column.id === columnId
+        ? { ...column, cardIds: [...column.cardIds, id] }
+        : column
+    ),
+  };
+};
+
+export const removeCard = (
+  board: BoardData,
+  columnId: string,
+  cardId: string
+): BoardData => {
+  const cards = { ...board.cards };
+  delete cards[cardId];
+  return {
+    ...board,
+    cards,
+    columns: board.columns.map((column) =>
+      column.id === columnId
+        ? { ...column, cardIds: column.cardIds.filter((id) => id !== cardId) }
+        : column
+    ),
+  };
+};

--- a/frontend/tests/kanban.spec.ts
+++ b/frontend/tests/kanban.spec.ts
@@ -1,13 +1,21 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
+
+const signIn = async (page: Page) => {
+  await page.getByLabel("Username").fill("user");
+  await page.getByLabel("Password").fill("password");
+  await page.getByRole("button", { name: /sign in/i }).click();
+  await expect(page.getByRole("heading", { name: "Kanban Studio" })).toBeVisible();
+};
 
 test("loads the kanban board", async ({ page }) => {
   await page.goto("/");
-  await expect(page.getByRole("heading", { name: "Kanban Studio" })).toBeVisible();
+  await signIn(page);
   await expect(page.locator('[data-testid^="column-"]')).toHaveCount(5);
 });
 
 test("adds a card to a column", async ({ page }) => {
   await page.goto("/");
+  await signIn(page);
   const firstColumn = page.locator('[data-testid^="column-"]').first();
   await firstColumn.getByRole("button", { name: /add a card/i }).click();
   await firstColumn.getByPlaceholder("Card title").fill("Playwright card");
@@ -18,6 +26,7 @@ test("adds a card to a column", async ({ page }) => {
 
 test("moves a card between columns", async ({ page }) => {
   await page.goto("/");
+  await signIn(page);
   const card = page.getByTestId("card-card-1");
   const targetColumn = page.getByTestId("column-col-review");
   const cardBox = await card.boundingBox();

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.115.5
+uvicorn[standard]==0.32.0
+httpx==0.28.1
+pydantic==2.10.2

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+python3 -m venv .venv
+source .venv/bin/activate
+python3 backend/app.py > /tmp/pm-backend.log 2>&1 &
+
+cd "$ROOT_DIR/frontend"
+npm install >/dev/null
+npm run dev > /tmp/pm-frontend.log 2>&1 &
+
+printf 'Backend and frontend started.\n'
+printf 'Open http://localhost:3000\n'

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -4,12 +4,12 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT_DIR"
 
-python3 -m venv .venv
+[ -d .venv ] || python3 -m venv .venv
 source .venv/bin/activate
 python3 backend/app.py > /tmp/pm-backend.log 2>&1 &
 
 cd "$ROOT_DIR/frontend"
-npm install >/dev/null
+[ -d node_modules ] || npm install >/dev/null
 npm run dev > /tmp/pm-frontend.log 2>&1 &
 
 printf 'Backend and frontend started.\n'

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-pkill -f "uvicorn backend.app:app" || true
+pkill -f "backend/app.py" || true
 pkill -f "next dev" || true
 printf 'Stopped local servers.\n'

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pkill -f "uvicorn backend.app:app" || true
+pkill -f "next dev" || true
+printf 'Stopped local servers.\n'


### PR DESCRIPTION
Replaces the stdlib http.server handler with a real FastAPI app so backend/tests/test_chat.py can import it (was failing to collect). Aligns scripts/stop.sh's pkill pattern with the actual backend process, adds sign-in flow coverage to the Playwright kanban specs, and checks in CLAUDE.md.

## Test plan
- [x] `python -m pytest backend/tests/` passes
- [x] `npm run test:unit` passes
- [x] `npm run test:e2e` passes
- [x] `npm run lint` passes